### PR TITLE
Fix wordnet errors for multiword args

### DIFF
--- a/bin/dic
+++ b/bin/dic
@@ -3,7 +3,7 @@
 # Taken from https://ddrscott.github.io/blog/2017/fzf-dictionary/
 
 if [ $# -eq 0 ]; then
-    wn $(spell) -over | fold
+    wn "$(spell)" -over | fold
 else
-    wn $1 -over | fold
+    wn "$1" -over | fold
 fi


### PR DESCRIPTION
If the suggestion contains multiple words, the preview has errors because it's not quoted.

Before: 
![image](https://user-images.githubusercontent.com/5385846/115973218-28565500-a508-11eb-94d6-14b02ec86547.png)


After:
![image](https://user-images.githubusercontent.com/5385846/115973222-32785380-a508-11eb-815c-ca1fcf34684d.png)


